### PR TITLE
Fix menu styles

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -14,7 +14,7 @@
 
 		/* Hide menu items on small screens */
 		@media screen and (max-width: 600px) {
-			.w3-bar-item {
+			.w3-bar .w3-bar-item {
 				display: none;
 			}
 


### PR DESCRIPTION
Update styles to use a more specific selector so that they override the default styling. This is needed to match https://github.com/gameboy9/gameboy9.github.io/blob/6e6f4835e399053968b81fb3386708de39c5a620/css/w3.css#L64C1-L64C21