### PR TITLE
Merge Queues Utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ From PowerShell:
 ```
 npm install -g local-web-server
 cd C:\Path\To\gameboy9.github.io\
-ws --spa mergequeues.html
+ws --spa index.html
 ```
 
 Browse to: http://machine-name:8000

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # gameboy9.github.io
-Personal page
+Calculators and tools for IFPA pinball tournaments.
+
+### Local testing
+
+From PowerShell:
+
+```
+npm install -g local-web-server
+cd C:\Path\To\gameboy9.github.io\
+ws --spa mergequeues.html
+```
+
+Browse to: http://machine-name:8000

--- a/css/w3.css
+++ b/css/w3.css
@@ -1,4 +1,4 @@
-﻿/* W3.CSS 4.15 December 2020 by Jan Egil and Borge Refsnes */
+﻿/* W3.CSS 5.02 March 31 2025 by Jan Egil and Borge Refsnes */
 html{box-sizing:border-box}*,*:before,*:after{box-sizing:inherit}
 /* Extract from normalize.css by Nicolas Gallagher and Jonathan Neal git.io/normalize */
 html{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}body{margin:0}
@@ -108,6 +108,8 @@ hr{border:0;border-top:1px solid #eee;margin:20px 0}
 .w3-round-small{border-radius:2px}.w3-round,.w3-round-medium{border-radius:4px}.w3-round-large{border-radius:8px}.w3-round-xlarge{border-radius:16px}.w3-round-xxlarge{border-radius:32px}
 .w3-row-padding,.w3-row-padding>.w3-half,.w3-row-padding>.w3-third,.w3-row-padding>.w3-twothird,.w3-row-padding>.w3-threequarter,.w3-row-padding>.w3-quarter,.w3-row-padding>.w3-col{padding:0 8px}
 .w3-container,.w3-panel{padding:0.01em 16px}.w3-panel{margin-top:16px;margin-bottom:16px}
+.w3-grid{display:grid}.w3-grid-padding{display:grid;gap:16px}.w3-flex{display:flex}
+.w3-text-center{text-align:center}.w3-text-bold,.w3-bold{font-weight:bold}.w3-text-italic,.w3-italic{font-style:italic}
 .w3-code,.w3-codespan{font-family:Consolas,"courier new";font-size:16px}
 .w3-code{width:auto;background-color:#fff;padding:8px 12px;border-left:4px solid #4CAF50;word-wrap:break-word}
 .w3-codespan{color:crimson;background-color:#f1f1f1;padding-left:4px;padding-right:4px;font-size:110%}
@@ -148,6 +150,7 @@ hr{border:0;border-top:1px solid #eee;margin:20px 0}
 .w3-button:hover{color:#000!important;background-color:#ccc!important}
 .w3-transparent,.w3-hover-none:hover{background-color:transparent!important}
 .w3-hover-none:hover{box-shadow:none!important}
+.w3-rtl{direction:rtl}.w3-ltr{direction:ltr}
 /* Colors */
 .w3-amber,.w3-hover-amber:hover{color:#000!important;background-color:#ffc107!important}
 .w3-aqua,.w3-hover-aqua:hover{color:#000!important;background-color:#00ffff!important}
@@ -175,6 +178,19 @@ hr{border:0;border-top:1px solid #eee;margin:20px 0}
 .w3-grey,.w3-hover-grey:hover,.w3-gray,.w3-hover-gray:hover{color:#000!important;background-color:#9e9e9e!important}
 .w3-light-grey,.w3-hover-light-grey:hover,.w3-light-gray,.w3-hover-light-gray:hover{color:#000!important;background-color:#f1f1f1!important}
 .w3-dark-grey,.w3-hover-dark-grey:hover,.w3-dark-gray,.w3-hover-dark-gray:hover{color:#fff!important;background-color:#616161!important}
+.w3-asphalt,.w3-hover-asphalt:hover{color:#fff!important;background-color:#343a40!important}
+.w3-crimson,.w3-hover-crimson:hover{color:#fff!important;background-color:#a20025!important}
+.w3-cobalt,w3-hover-cobalt:hover{color:#fff!important;background-color:#0050ef!important}
+.w3-emerald,.w3-hover-emerald:hover{color:#fff!important;background-color:#008a00!important}
+.w3-olive,.w3-hover-olive:hover{color:#fff!important;background-color:#6d8764!important}
+.w3-paper,.w3-hover-paper:hover{color:#000!important;background-color:#f8f9fa!important}
+.w3-sienna,.w3-hover-sienna:hover{color:#fff!important;background-color:#a0522d!important}
+.w3-taupe,.w3-hover-taupe:hover{color:#fff!important;background-color:#87794e!important}
+.w3-danger{color:#fff!important;background-color:#dd0000!important}
+.w3-note{color:#000!important;background-color:#fff599!important}
+.w3-info{color:#fff!important;background-color:#0a6fc2!important}
+.w3-warning{color:#000!important;background-color:#ffb305!important}
+.w3-success{color:#fff!important;background-color:#008a00!important}
 .w3-pale-red,.w3-hover-pale-red:hover{color:#000!important;background-color:#ffdddd!important}
 .w3-pale-green,.w3-hover-pale-green:hover{color:#000!important;background-color:#ddffdd!important}
 .w3-pale-yellow,.w3-hover-pale-yellow:hover{color:#000!important;background-color:#ffffcc!important}

--- a/js/mergequeues.js
+++ b/js/mergequeues.js
@@ -19,6 +19,24 @@ class QueuesManager {
 		this.queueDisplay = undefined;
 		this.lastLoadTournamentInfoTimestamp = undefined;
 		this.loadTournamentInfoNeeded = true;
+		this.arenaOrder = "";
+	}
+
+	sortKeysByArenaOrder(arenaKeys) {
+		// Sort the queues by the provided arena order
+		const arenaOrderList = this.arenaOrder.split(",").map(s => s.trim()).filter(s => s !== "");
+		if (arenaOrderList.length > 0) {
+			arenaKeys.sort((arenaIdA, arenaIdB) => {
+				var indexOfA = arenaOrderList.findIndex(arenaPrefix => QueuesManager.manager.getArenaName(arenaIdA).startsWith(arenaPrefix));
+				var indexOfB = arenaOrderList.findIndex(arenaPrefix => QueuesManager.manager.getArenaName(arenaIdB).startsWith(arenaPrefix));
+				if (indexOfA === -1 && indexOfB === -1) return 0;
+				if (indexOfA === -1) return 1;
+				if (indexOfB === -1) return -1;
+				if (indexOfA > indexOfB) return 1;
+				if (indexOfA < indexOfB) return -1;
+				return 0;
+			});
+		}
 	}
 
 	getArenaName(arenaId) {
@@ -120,21 +138,8 @@ class QueuesManager {
 		this.queueSummaryDisplay = document.createElement("div");
 
 		var arenaKeys = Array.from(this.mergedArenas.keys());
+		this.sortKeysByArenaOrder(arenaKeys);
 
-		// Sort the queues by the provided arena order
-		const arenaOrderList = this.arenaOrder.split(",").map(s => s.trim()).filter(s => s !== "");
-		if (arenaOrderList.length > 0) {
-			arenaKeys.sort((arenaIdA, arenaIdB) => {
-				var indexOfA = arenaOrderList.findIndex(arenaPrefix => QueuesManager.manager.getArenaName(arenaIdA).startsWith(arenaPrefix));
-				var indexOfB = arenaOrderList.findIndex(arenaPrefix => QueuesManager.manager.getArenaName(arenaIdB).startsWith(arenaPrefix));
-				if (indexOfA === -1 && indexOfB === -1) return 0;
-				if (indexOfA === -1) return 1;
-				if (indexOfB === -1) return -1;
-				if (indexOfA > indexOfB) return 1;
-				if (indexOfA < indexOfB) return -1;
-				return 0;
-			});
-		}
 
 		var queueCount = arenaKeys.length;
 		var queueKey = undefined;
@@ -205,20 +210,7 @@ class QueuesManager {
 		this.queueDisplay.classList.add("queue-list-grid-3");
 
 		var arenaKeys = Object.keys(this.queues);
-		// Sort the queues by the provided arena order
-		const arenaOrderList = this.arenaOrder.split(",").map(s => s.trim()).filter(s => s !== "");
-		if (arenaOrderList.length > 0) {
-			arenaKeys.sort((arenaIdA, arenaIdB) => {
-				var indexOfA = arenaOrderList.findIndex(arenaPrefix => QueuesManager.manager.getArenaName(arenaIdA).startsWith(arenaPrefix));
-				var indexOfB = arenaOrderList.findIndex(arenaPrefix => QueuesManager.manager.getArenaName(arenaIdB).startsWith(arenaPrefix));
-				if (indexOfA === -1 && indexOfB === -1) return 0;
-				if (indexOfA === -1) return 1;
-				if (indexOfB === -1) return -1;
-				if (indexOfA > indexOfB) return 1;
-				if (indexOfA < indexOfB) return -1;
-				return 0;
-			});
-		}
+		this.sortKeysByArenaOrder(arenaKeys);
 
 		for (const queueKey of arenaKeys) {
 			const queueItem = this.queues[queueKey];

--- a/js/mergequeues.js
+++ b/js/mergequeues.js
@@ -1,0 +1,497 @@
+class Player {
+	constructor(id, topScore) {
+		this.id = id;
+		this.topScore = topScore;
+		this.points = 0;
+		this.score = 0;
+	}
+}
+
+class QueuesManager {
+	static manager;
+
+	static createOrUpdate(matchPlayApiKey, ...tournamentIdList) {
+		if (QueuesManager.manager === undefined) {
+			QueuesManager.manager = new QueuesManager(matchPlayApiKey, ...tournamentIdList);
+		} else {
+			QueuesManager.matchPlayApiKey = matchPlayApiKey;
+			QueuesManager.tournamentIdList = tournamentIdList;
+		}
+	}
+
+	constructor(matchPlayApiKey, ...tournamentIdList) {
+		this.matchPlayApiKey = matchPlayApiKey;
+		this.tournamentIdList = tournamentIdList;
+		this.queues = {};
+		this.tournamentInfo = {};
+		this.mergedArenas = new Map();
+		this.queueDisplay = undefined;
+		this.lastLoadTournamentInfoTimestamp = undefined;
+		this.loadTournamentInfoNeeded = true;
+	}
+
+	getArenaName(arenaId) {
+		var foundArena = undefined;
+
+		Object.values(this.tournamentInfo).forEach(t => {
+			if (foundArena === undefined) {
+				foundArena = t.arenas.find((a) => a.arenaId == arenaId);
+			}
+		});
+
+		return foundArena?.name ?? "Unknown arena - " + arenaId;
+	}
+
+	getQueueName(tournamentId) {
+		var name = this.shortNames[tournamentId] || this.tournamentInfo[tournamentId].name;
+  		if (name.trim() === "") {
+			name = "\u00A0"; // &nbsp;
+  		}
+		return name;
+	}
+
+	getPlayer(tournamentId, playerId) {
+		return this.tournamentInfo[tournamentId].players.find((p) => p.playerId == playerId);
+	}
+
+	async getPlayerName(tournamentId, playerId) {
+		var player = this.getPlayer(tournamentId, playerId);
+		if (player === undefined) {
+			this.loadTournamentInfoNeeded = true;
+			await this.loadTournamentInfoWithDebounce()
+			player = this.getPlayer(tournamentId, playerId);
+		}
+		return player?.name ?? "Name unknown - " + playerId;
+	}
+
+	async buildSummaryPlayerName(playerInfo) {
+		var playerName = await this.getPlayerName(playerInfo.tournamentId, playerInfo.playerId);
+		var prefix = this.getQueueName(playerInfo.tournamentId).substring(0, 1);
+		if (prefix?.trim() === "") {
+			prefix = "";
+		} else {
+			prefix += " - ";
+		}
+		return prefix + playerName;
+	}
+
+	timeSinceToText(currentTime, pastTime) {
+		const lessthan1Minute = "just joined";
+		const lessthan2Minutes = "1 minute";
+		const morethan2MinutesSuffix = " minutes";
+		const morethan999Minutes = "forever";
+
+		var past = Date.parse(pastTime);
+		var differenceinMs = currentTime - past;
+
+		var seconds = Math.floor(differenceinMs / 1000);
+		var minutes = Math.floor(seconds / 60);
+
+		if (minutes < 1) {
+			return lessthan1Minute;
+		} else if (minutes < 2) {
+			return lessthan2Minutes;
+		} else if (minutes > 999) {
+			return morethan999Minutes;
+		} else {
+			return minutes + morethan2MinutesSuffix;
+		}
+	}
+
+	buildLastUpdatedText(dataLoadTimestamp) {
+		var hoursInt = dataLoadTimestamp.getHours()
+		var timeSuffix;
+		var hours;
+		if (hoursInt === 0) {
+			timeSuffix = "am";
+			hours = "12";
+		} else if (hoursInt < 12) {
+			timeSuffix = "am"
+			hours = String(hoursInt);
+		} else if (hoursInt === 12) {
+			timeSuffix = "pm"
+			hours = "12";
+		} else {
+			timeSuffix = "pm";
+			hours = String(hoursInt - 12);
+		}
+  		var minutes = String(dataLoadTimestamp.getMinutes()).padStart(2, '0');
+  		var seconds = String(dataLoadTimestamp.getSeconds()).padStart(2, '0');
+		var lastUpdatedText = `${hours}:${minutes}:${seconds} ${timeSuffix}`;
+		return lastUpdatedText;
+	}
+
+	async displayQueuesSummary(currentTime) {
+		var queueSummaryTitle = document.getElementById("queueSummaryTitle");
+		var queueSummaryHeader = document.getElementById("queueSummaryHeader");
+		var rowTemplate = document.getElementById("queueSummaryRowTemplate");
+
+		if (this.queueSummaryDisplay !== undefined) {
+			// Cleanup old elements
+			this.queueSummaryDisplay.remove();
+		}
+
+		// Hold new elements outside of the DOM until they are ready to display
+		this.queueSummaryDisplay = document.createElement("div");
+
+		var arenaKeys = Array.from(this.mergedArenas.keys());
+		var queueCount = arenaKeys.length;
+		var queueKey = undefined;
+		var queueItem = undefined;
+
+		for (let i = 0; i < queueCount; i++) {
+			var queueSummaryRow = rowTemplate.cloneNode(true);
+			queueSummaryRow.id = 'summaryrow-' + i;
+			queueSummaryRow.classList.remove("w3-hide");
+
+			queueKey = arenaKeys[i];
+			queueItem = this.queues[queueKey];
+
+			var playerOne = queueItem?.[0];
+			var playerTwo = queueItem?.[1];
+			var playerThree = queueItem?.[2];
+			var queueIsEmpty = (undefined === (playerOne ?? playerTwo ?? playerThree));
+
+			var queueRowCols = queueSummaryRow.getElementsByTagName("div");
+			queueRowCols[0].textContent = this.getArenaName(queueKey);
+			if (queueIsEmpty) {
+				queueRowCols[1].textContent = "Queue is empty";
+			} else {
+				queueRowCols[1].textContent = await this.buildSummaryPlayerName(playerOne);
+			}
+			if (playerTwo === undefined) {
+				queueRowCols[2].textContent = "\u00A0"; // &nbsp;
+			} else {
+				queueRowCols[2].textContent = await this.buildSummaryPlayerName(playerTwo);
+			}
+			if (playerThree === undefined) {
+				queueRowCols[3].textContent = "\u00A0"; // &nbsp;
+			} else {
+				queueRowCols[3].textContent = await this.buildSummaryPlayerName(playerThree);
+			}
+
+			if (i > 0) {
+				Object.keys(queueRowCols).forEach(k => queueRowCols[k].classList.remove("w3-border-top"));
+			}
+
+			if (i % 2 === 1) {
+				Object.keys(queueRowCols).forEach(k => queueRowCols[k].classList.add("w3-pale-green"));
+			}
+
+			this.queueSummaryDisplay.appendChild(queueSummaryRow);
+		}
+
+		queueSummaryTitle.classList.remove("w3-hide");
+		queueSummaryHeader.classList.remove("w3-hide");
+		// Add elements into the DOM
+		rowTemplate.insertAdjacentElement("afterend", this.queueSummaryDisplay);
+
+	}
+
+	async displayFullQueues(currentTime) {
+		var fullQueuesTitle = document.getElementById("fullQueuesTitle");
+		var nameTemplate = document.getElementById("queueNameTemplate");
+		var headerTemplate = document.getElementById("queueHeaderTemplate");
+		var rowTemplate = document.getElementById("queueRowTemplate");
+
+		if (this.queueDisplay !== undefined) {
+			// Cleanup old elements
+			this.queueDisplay.remove();
+		}
+
+		// Hold new elements outside of the DOM until they are ready to display
+		this.queueDisplay = document.createElement("div");
+		this.queueDisplay.classList.add("w3-flex");
+		this.queueDisplay.classList.add("queue-list-flex");
+
+		for (const [queueKey, queueItem] of Object.entries(this.queues)) {
+			var queueFlexItem = document.createElement("div");
+			queueFlexItem.classList.add("queue-flex");
+			this.queueDisplay.appendChild(queueFlexItem);
+
+			var queueName = nameTemplate.cloneNode(true);
+			queueName.id = queueKey + '-name';
+			queueName.classList.remove("w3-hide");
+			queueName.getElementsByTagName("h3")[0].textContent = this.getArenaName(queueKey);
+			queueFlexItem.appendChild(queueName);
+
+			var queueHeader = headerTemplate.cloneNode(true);
+			queueHeader.id = queueKey + '-header';
+			queueHeader.classList.remove("w3-hide");
+			queueFlexItem.appendChild(queueHeader);
+
+			var isTopRow = true;
+			for (const [playerIndex, queuedPlayer] of Object.entries(queueItem)) {
+				var queueRow = rowTemplate.cloneNode(true);
+				queueRow.id = queueItem.arenaId + "-" + playerIndex;
+				queueRow.classList.remove("w3-hide");
+				var queueRowCols = queueRow.getElementsByTagName("div");
+				queueRowCols[0].textContent = parseInt(playerIndex) + 1;
+				queueRowCols[1].textContent = await this.getPlayerName(queuedPlayer.tournamentId, queuedPlayer.playerId);
+				queueRowCols[2].textContent = this.getQueueName(queuedPlayer.tournamentId);
+				queueRowCols[3].textContent = this.timeSinceToText(currentTime, queuedPlayer.createdAt);
+				if (!isTopRow) {
+					Object.keys(queueRowCols).forEach(k => queueRowCols[k].classList.remove("w3-border-top"));
+				}
+				queueFlexItem.appendChild(queueRow);
+				isTopRow = false;
+			}
+		}
+		
+		//fullQueuesTitle.classList.remove("w3-hide");
+		// Add elements into the DOM
+		rowTemplate.insertAdjacentElement("afterend", this.queueDisplay);
+	}
+
+	async displayQueues(dataLoadTimestamp) {
+		console.log("Queues to display:");
+		console.dir(this.queues);
+
+		const currentTime = new Date();
+
+		await this.displayQueuesSummary();
+		await this.displayFullQueues(currentTime);
+
+		if (dataLoadTimestamp instanceof Date) {
+			var lastUpdatedText = this.buildLastUpdatedText(dataLoadTimestamp);
+			var lastUpdated = document.getElementById("lastUpdated");
+			lastUpdated.classList.remove("w3-hide");
+			lastUpdated.textContent = "Last updated " + lastUpdatedText;
+		}
+	}
+
+	compareByCreatedAt(a, b) {
+		if (a.createdAt < b.createdAt) {
+			return -1;
+		}
+		if (a.createdAt > b.createdAt) {
+			return 1;
+		}
+		return 0;
+	}
+
+	getTournamentInfoUrl(tournamentId) {
+		var url = new URL("https://app.matchplay.events/api/tournaments/" + tournamentId);
+		url.searchParams.append("includePlayers", 1);
+		url.searchParams.append("includeArenas", 1);
+		return url;
+	}
+
+	getQueuesUrl(tournamentId) {
+		return "https://app.matchplay.events/api/tournaments/" + tournamentId + "/queues";
+	}
+
+	makeRequest(url) {
+		return new Promise((resolve, reject) => {
+			const xhr = new XMLHttpRequest();
+			xhr.open('GET', url);
+			xhr.setRequestHeader("Authorization", "Bearer " + this.matchPlayApiKey);
+
+			xhr.onload = () => {
+				if (xhr.status >= 200 && xhr.status < 300) {
+					resolve(xhr.responseText);
+				} else {
+					reject(new Error(`Request failed with status ${xhr.status}`));
+				}
+			};
+
+			xhr.onerror = () => {
+				reject(new Error('Network error'));
+			};
+
+			xhr.send();
+		});
+	}
+
+	async loadTournamentInfoWithDebounce() {
+		const debounceMilliseconds = 1000 * 60; // 60 seconds
+		var skipLoad = true;
+
+		if (this.loadTournamentInfoNeeded) {
+			if (this.lastLoadTournamentInfoTimestamp === undefined) {
+				skipLoad = false;
+			} else {
+				var timeSinceLastRefresh = (new Date() - this.lastLoadTournamentInfoTimestamp);
+				if (timeSinceLastRefresh < debounceMilliseconds) {
+					console.log(`Skipping tournament load request, last refresh was ${timeSinceLastRefresh} ms ago`);
+				} else {
+					console.log(`Loading tournament info after debounce of ${timeSinceLastRefresh} ms`);
+					skipLoad = false;
+				}
+			}
+		}
+
+		if (!skipLoad) {
+			await this.loadTournamentInfo();
+		}
+	}
+
+	loadTournamentInfo() {
+		const requests = this.tournamentIdList.map(tournamentId => this.makeRequest(this.getTournamentInfoUrl(tournamentId)));
+
+		return Promise.all(requests)
+        .then(results => {
+            console.log('Load all tournament info requests succeeded:', results);
+            // Process the results from all successful requests
+			var jsonResults = results.map((r) => JSON.parse(r));
+
+			// Clear previous tournament info
+			this.tournamentInfo = {};
+			this.mergedArenas.clear();
+
+			jsonResults.forEach(response => {
+				console.log("Load tournament info response:");
+				console.dir(response);
+
+				this.tournamentInfo[response.data.tournamentId] = response.data;
+
+				response.data.arenas.forEach(arena => {
+					if (!this.mergedArenas.has(arena.arenaId)) {
+						this.mergedArenas.set(arena.arenaId, arena);
+					}
+				});
+			});
+
+			this.lastLoadTournamentInfoTimestamp = new Date();
+			this.loadTournamentInfoNeeded = false;
+        })
+        .catch(error => {
+            console.error('One or more load all queues requests failed:', error);
+            // Handle the error from the first rejected request
+        });
+	}
+
+	loadAllQueues() {
+		const requests = this.tournamentIdList.map(tournamentId => this.makeRequest(this.getQueuesUrl(tournamentId)));
+
+		return Promise.all(requests)
+        .then(results => {
+            console.log('Load all queues requests succeeded:', results);
+            // Process the results from all successful requests
+			var jsonResults = results.map((r) => JSON.parse(r));
+
+			// Clear previous queues
+			this.queues = {};
+
+			jsonResults.forEach(response => {
+				console.log("Load queue response:");
+				console.dir(response);
+
+				Object.keys(response.data).forEach(key => {
+					if (this.queues[key] === undefined) {
+						this.queues[key] = [];
+					}
+					this.queues[key].push(...response.data[key]);
+				});
+			});
+
+			// Sort each queue by time the player joined the queue
+			Object.keys(this.queues).forEach(k => {
+				this.queues[k].sort(this.compareByCreatedAt);
+			});
+        })
+        .catch(error => {
+            console.error('One or more load all queues requests failed:', error);
+            // Handle the error from the first rejected request
+        });
+	}
+}
+
+function cleanupApiKeyInput() {
+	const bearerPrefix = "bearer ";
+	const bearerPrefixLength = bearerPrefix.length
+	var apiKeyElement = document.getElementById("matchPlayApiKey");
+	var inputPrefix = apiKeyElement.value.substring(0, bearerPrefixLength);
+	if (inputPrefix.toLowerCase() === bearerPrefix) {
+		apiKeyElement.value = apiKeyElement.value.substring(bearerPrefix.length);
+	}
+}
+
+function loadParameters() {
+	cleanupApiKeyInput();
+	var matchPlayApiKey = document.getElementById("matchPlayApiKey").value;
+	var tournamentIdA = parseInt(document.getElementById("tournamentIdA").value);
+	var tournamentShortNameA = document.getElementById("tournamentShortNameA").value;
+	var tournamentIdB = parseInt(document.getElementById("tournamentIdB").value);
+	var tournamentShortNameB = document.getElementById("tournamentShortNameB").value;
+
+	QueuesManager.createOrUpdate(matchPlayApiKey, tournamentIdA, tournamentIdB);
+	QueuesManager.manager.shortNames = {
+		[tournamentIdA]: tournamentShortNameA,
+		[tournamentIdB]: tournamentShortNameB
+	};
+}
+
+async function loadQueuesButton() {
+	var dataLoadTimestamp = new Date();
+
+	loadParameters();
+
+	await QueuesManager.manager.loadTournamentInfoWithDebounce();
+	await QueuesManager.manager.loadAllQueues();
+	await QueuesManager.manager.displayQueues(dataLoadTimestamp);
+}
+
+async function loadPlayersButton() {
+	loadParameters();
+	
+	await QueuesManager.manager.loadTournamentInfo()
+	await QueuesManager.manager.displayQueues();
+}
+
+async function autoLoadQueuesAndRepeat() {
+	const delayTime = 1000 * 30; // 30 seconds
+
+	if (QueuesManager.manager.autoLoadActive) {
+		await loadQueuesButton();
+		QueuesManager.manager.pendingAutoLoadTimeoutId = setTimeout(autoLoadQueuesAndRepeat, delayTime);
+	}
+}
+
+async function startAutoLoadQueuesButton() {
+	loadParameters();
+
+	QueuesManager.manager.autoLoadActive = true;
+	autoLoadQueuesAndRepeat();
+
+	document.getElementById("startAutoLoadButton").classList.add("w3-hide");
+	document.getElementById("stopAutoLoadButton").classList.remove("w3-hide");
+}
+
+function stopAutoLoadQueuesButton() {
+	loadParameters();
+
+	QueuesManager.manager.autoLoadActive = false;
+	if (QueuesManager.manager.pendingAutoLoadTimeoutId !== undefined) {
+		clearTimeout(QueuesManager.pendingAutoLoadTimeoutId);
+		QueuesManager.manager.pendingAutoLoadTimeoutId = undefined;
+	}
+
+	document.getElementById("startAutoLoadButton").classList.remove("w3-hide");
+	document.getElementById("stopAutoLoadButton").classList.add("w3-hide");
+}
+
+function initializeFromStorage() {
+	const storageItemKey = "mergequeues";
+	const itemValue = localStorage.getItem(storageItemKey);
+	const item = JSON.parse(itemValue);
+	if (item?.matchPlayApiKey !== undefined) {
+		document.getElementById("matchPlayApiKey").value = item.matchPlayApiKey;
+		loadParameters();
+	}
+}
+
+function saveApiKey() {
+	const storageItemKey = "mergequeues";
+	loadParameters();
+	const item = {
+		matchPlayApiKey: QueuesManager.manager.matchPlayApiKey
+	};
+
+	localStorage.setItem(storageItemKey, JSON.stringify(item));
+}
+
+function clearSavedApiKey() {
+	const storageItemKey = "mergequeues";
+	localStorage.removeItem(storageItemKey);
+}

--- a/js/mergequeues.js
+++ b/js/mergequeues.js
@@ -120,6 +120,22 @@ class QueuesManager {
 		this.queueSummaryDisplay = document.createElement("div");
 
 		var arenaKeys = Array.from(this.mergedArenas.keys());
+
+		// Sort the queues by the provided arena order
+		const arenaOrderList = this.arenaOrder.split(",").map(s => s.trim()).filter(s => s !== "");
+		if (arenaOrderList.length > 0) {
+			arenaKeys.sort((arenaIdA, arenaIdB) => {
+				var indexOfA = arenaOrderList.findIndex(arenaPrefix => QueuesManager.manager.getArenaName(arenaIdA).startsWith(arenaPrefix));
+				var indexOfB = arenaOrderList.findIndex(arenaPrefix => QueuesManager.manager.getArenaName(arenaIdB).startsWith(arenaPrefix));
+				if (indexOfA === -1 && indexOfB === -1) return 0;
+				if (indexOfA === -1) return 1;
+				if (indexOfB === -1) return -1;
+				if (indexOfA > indexOfB) return 1;
+				if (indexOfA < indexOfB) return -1;
+				return 0;
+			});
+		}
+
 		var queueCount = arenaKeys.length;
 		var queueKey = undefined;
 		var queueItem = undefined;
@@ -185,14 +201,28 @@ class QueuesManager {
 
 		// Hold new elements outside of the DOM until they are ready to display
 		this.queueDisplay = document.createElement("div");
-		// this.queueDisplay.classList.add("w3-flex");
-		// this.queueDisplay.classList.add("queue-list-flex");
 		this.queueDisplay.classList.add("w3-grid");
 		this.queueDisplay.classList.add("queue-list-grid-3");
 
-		for (const [queueKey, queueItem] of Object.entries(this.queues)) {
+		var arenaKeys = Object.keys(this.queues);
+		// Sort the queues by the provided arena order
+		const arenaOrderList = this.arenaOrder.split(",").map(s => s.trim()).filter(s => s !== "");
+		if (arenaOrderList.length > 0) {
+			arenaKeys.sort((arenaIdA, arenaIdB) => {
+				var indexOfA = arenaOrderList.findIndex(arenaPrefix => QueuesManager.manager.getArenaName(arenaIdA).startsWith(arenaPrefix));
+				var indexOfB = arenaOrderList.findIndex(arenaPrefix => QueuesManager.manager.getArenaName(arenaIdB).startsWith(arenaPrefix));
+				if (indexOfA === -1 && indexOfB === -1) return 0;
+				if (indexOfA === -1) return 1;
+				if (indexOfB === -1) return -1;
+				if (indexOfA > indexOfB) return 1;
+				if (indexOfA < indexOfB) return -1;
+				return 0;
+			});
+		}
+
+		for (const queueKey of arenaKeys) {
+			const queueItem = this.queues[queueKey];
 			var queueFlexItem = document.createElement("div");
-			// queueFlexItem.classList.add("queue-flex");
 			queueFlexItem.classList.add("rounded-box");
 			queueFlexItem.classList.add("w3-border-blue");
 			queueFlexItem.classList.add("w3-card");
@@ -440,6 +470,7 @@ class MergeQueuesSettings {
 	static getTournamentShortNameAEl = () => document.getElementById("tournamentShortNameA");
 	static getTournamentIdBEl = () => document.getElementById("tournamentIdB");
 	static getTournamentShortNameBEl = () => document.getElementById("tournamentShortNameB");
+	static getArenaOrderEl = () => document.getElementById("arenaOrder");
 
 	hasRequiredMatchPlayApiKey() {
 		const keyIsBlank = (this.settingsValues.matchPlayApiKey?.trim() ?? "") === "";
@@ -472,6 +503,7 @@ class MergeQueuesSettings {
 		currentSavedSettingsValues.tournamentShortNameA = this.settingsValues.tournamentShortNameA;
 		currentSavedSettingsValues.tournamentIdB = this.settingsValues.tournamentIdB;
 		currentSavedSettingsValues.tournamentShortNameB = this.settingsValues.tournamentShortNameB;
+		currentSavedSettingsValues.arenaOrder = this.settingsValues.arenaOrder;
 		localStorage.setItem(MergeQueuesSettings.getStorageItemKey(), JSON.stringify(currentSavedSettingsValues));
 	}
 
@@ -482,6 +514,7 @@ class MergeQueuesSettings {
 		delete currentSavedSettingsValues.tournamentShortNameA;
 		delete currentSavedSettingsValues.tournamentIdB;
 		delete currentSavedSettingsValues.tournamentShortNameB;
+		delete currentSavedSettingsValues.arenaOrder;
 		localStorage.setItem(MergeQueuesSettings.getStorageItemKey(), JSON.stringify(currentSavedSettingsValues));
 	}
 
@@ -505,6 +538,7 @@ class MergeQueuesSettings {
 		this.settingsValues.tournamentShortNameA = MergeQueuesSettings.getTournamentShortNameAEl().value;
 		this.settingsValues.tournamentIdB = parseInt(MergeQueuesSettings.getTournamentIdBEl().value);
 		this.settingsValues.tournamentShortNameB = MergeQueuesSettings.getTournamentShortNameBEl().value;
+		this.settingsValues.arenaOrder = MergeQueuesSettings.getArenaOrderEl().value;
 	}
 
 	writeToPage() {
@@ -513,6 +547,7 @@ class MergeQueuesSettings {
 		MergeQueuesSettings.getTournamentShortNameAEl().value = this.settingsValues.tournamentShortNameA ?? "";
 		MergeQueuesSettings.getTournamentIdBEl().value = this.settingsValues.tournamentIdB ?? "";
 		MergeQueuesSettings.getTournamentShortNameBEl().value = this.settingsValues.tournamentShortNameB ?? "";
+		MergeQueuesSettings.getArenaOrderEl().value = this.settingsValues.arenaOrder ?? "";
 	}
 
 	applyToQueuesManager() {
@@ -525,6 +560,8 @@ class MergeQueuesSettings {
 			[this.settingsValues.tournamentIdA]: this.settingsValues.tournamentShortNameA,
 			[this.settingsValues.tournamentIdB]: this.settingsValues.tournamentShortNameB
 		};
+
+		QueuesManager.manager.arenaOrder = this.settingsValues.arenaOrder;
 	}
 
 }

--- a/menu.html
+++ b/menu.html
@@ -13,7 +13,7 @@
 		}
 
 		/* Hide menu items on small screens */
-		@media screen and (max-width: 600px) {
+		@media screen and (max-width: 835px) {
 			.w3-bar .w3-bar-item {
 				display: none;
 			}
@@ -32,6 +32,7 @@
 		<a href="targetmatch.html" class="w3-bar-item w3-button">Target Matchplay</a>
 		<a href="pacematch.html" class="w3-bar-item w3-button">Pace Matchplay</a>
 		<a href="doubleelim.html" class="w3-bar-item w3-button">Double Elimination</a>
+		<a href="mergequeues.html" class="w3-bar-item w3-button w3-light-blue">Merge Queues</a>
 	</div>
 </body>
 </html>

--- a/menu.html
+++ b/menu.html
@@ -13,7 +13,7 @@
 		}
 
 		/* Hide menu items on small screens */
-		@media screen and (max-width: 835px) {
+		@media screen and (max-width: 1050px) {
 			.w3-bar .w3-bar-item {
 				display: none;
 			}

--- a/mergequeues.html
+++ b/mergequeues.html
@@ -16,21 +16,14 @@
 			white-space: nowrap;
 		}
 
+		.input-wide {
+			width: 400px;
+			max-width: 60%;
+		}
+
 		/* Used in mergequeues.js */
 		.queue-list-grid-3 {
-			grid-template-columns:auto auto auto;
-		}
-
-		/* Used in mergequeues.js */
-		.queue-list-flex {
-			flex-wrap: wrap;
-		}
-
-		/* Used in mergequeues.js */
-		.queue-flex {
-			flex-grow: 0;
-			flex-shrink: 0;
-			flex-basis: 444px;
+			grid-template-columns: auto auto auto;
 		}
 
 		/* Used in mergequeues.js */
@@ -41,6 +34,7 @@
 			margin: 6px;
 		}
 
+		/* Used in mergequeues.js */
 		.rounded-box > .w3-container {
 			padding-left: 8px;
 			padding-right: 8px;
@@ -93,6 +87,12 @@
 		<div class="w3-container w3-row" style="margin-top: 8px;">
 			<label for="tournamentShortNameB">Queue name: </label>
 			<input type="text" id="tournamentShortNameB" name="tournamentShortNameB" />
+			(optional)
+		</div>
+
+		<div class="w3-container w3-row" style="margin-top: 16px;">
+			<label for="arenaOrder">Arena order: </label>
+			<input type="text" class="input-wide" id="arenaOrder" name="arenaOrder" title="A comma separate list of arena names (or partial arena names). Example: Jurassic Park (Pro), The Addam, Jurassic Park (Prem, Galaxy" />
 			(optional)
 		</div>
 		<div class="w3-container w3-row" style="margin-top: 8px;">

--- a/mergequeues.html
+++ b/mergequeues.html
@@ -12,14 +12,16 @@
 			white-space: nowrap;
 		}
 
-		.border-left-thick {
-			border-left: 5px solid #ccc;
+		.nowrap {
+			white-space: nowrap;
 		}
 
+		/* Used in mergequeues.js */
 		.queue-list-flex {
 			flex-wrap: wrap;
 		}
 
+		/* Used in mergequeues.js */
 		.queue-flex {
 			flex-grow: 0;
 			flex-shrink: 0;
@@ -28,48 +30,66 @@
 	</style>
 </head>
 
-<body onload="initializeFromStorage()">
+<body onload="initializeSettings()">
 	<div w3-include-html="menu.html"></div>
 
-	<div class="w3-container w3-row" style="margin-top: 64px;">
-		<label for="matchPlayApiKey">Match Play Events API Token: </label>
-		<input type="password" id="matchPlayApiKey" name="matchPlayApiKey" />
-		<a class="w3-button" href="https://app.matchplay.events/api-docs/#authenticating-requests" title="Match Play Events API Authentication Documentation">🛈</a>
-		<a class="w3-button" href="https://app.matchplay.events/account/tokens" title="Create an API Token in your MPE Account Settings">🔑</a>
-		<button class="w3-button w3-dark-grey w3-hover-black w3-round" type="button" onclick="saveApiKey()" title="Writes your key to browser local storage">Save API Key</button>
-		<button class="w3-button w3-dark-grey w3-hover-black w3-round" type="button" onclick="clearSavedApiKey()" title="Clears any key saved in browser local storage">Clear Saved Key</button>
+	<!-- Prevents the menu from covering the content -->
+	<div class="w3-container w3-row" style="margin-top: 48px;"></div>
+
+	<div id="parametersSection">
+		<div class="w3-container w3-row" style="margin-top: 16px;">
+			<label for="matchPlayApiKey">Match Play Events API Token: </label>
+			<input type="password" id="matchPlayApiKey" name="matchPlayApiKey" />
+		</div>
+		<div class="w3-container w3-row w3-text-red w3-hide" style="margin-top: 8px;" id="matchPlayKeyRequiredMessage">
+			A Match Play Events API Token is required. If you don't already have one, click Get Token to visit your MPE account settings page and create one.
+		</div>
+		<div class="w3-container w3-row" style="margin-top: 8px;">
+			<a class="w3-button" href="https://app.matchplay.events/api-docs/#authenticating-requests" title="Match Play Events API Authentication Documentation">🛈 Info</a>
+			<a class="w3-button" href="https://app.matchplay.events/account/tokens" title="Create an API Token in your MPE Account Settings">🔑 Get Token</a>
+			<button class="w3-button w3-dark-grey w3-hover-black w3-round" type="button" onclick="saveApiKey()" id="saveApiKeyButton" title="Writes this token to browser local storage">Save API Token</button>
+			<button class="w3-button w3-dark-grey w3-hover-black w3-round" type="button" onclick="clearSavedApiKey()" id="clearSavedApiKeyButton" title="Clears any token saved in browser local storage">Clear Saved Token</button>
+			<span id="saveKeyStatus"></span>
+		</div>
+		
+		<div class="w3-container w3-row" style="margin-top: 16px;">
+			<label for="tournamentIdA">Tournament 1: </label>
+			<input type="number" id="tournamentIdA" name="tournamentIdA" />
+		</div>
+		<div class="w3-container w3-row" style="margin-top: 8px;">
+			<label for="tournamentShortNameA">Queue name: </label>
+			<input type="text" id="tournamentShortNameA" name="tournamentShortNameA" />
+			(optional)
+		</div>
+		
+		<div class="w3-container w3-row" style="margin-top: 16px;">
+			<label for="tournamentIdB">Tournament 2: </label>
+			<input type="number" id="tournamentIdB" name="tournamentIdB" />
+		</div>
+		<div class="w3-container w3-row" style="margin-top: 8px;">
+			<label for="tournamentShortNameB">Queue name: </label>
+			<input type="text" id="tournamentShortNameB" name="tournamentShortNameB" />
+			(optional)
+		</div>
+		<div class="w3-container w3-row" style="margin-top: 8px;">
+			<button class="w3-button w3-dark-grey w3-hover-black w3-round" type="button" onclick="saveParameters()" id="saveParametersButton" title="Writes these parameters to local storage">Save Settings</button>
+			<button class="w3-button w3-dark-grey w3-hover-black w3-round" type="button" onclick="clearSavedParameters()" id="clearSavedParametersButton" title="Clears any parameters saved in browser local storage">Clear Saved Settings</button>
+			<span id="saveParametersStatus"></span>
+		</div>
 	</div>
-	
-	<div class="w3-container w3-row" style="margin-top: 16px;">
-		<label for="tournamentIdA">Tournament 1: </label>
-		<input type="number" id="tournamentIdA" name="tournamentIdA" value="198946" />
-	</div>
-	<div class="w3-container w3-row" style="margin-top: 8px;">
-		<label for="tournamentShortNameA">Queue name: </label>
-		<input type="text" id="tournamentShortNameA" name="tournamentShortNameA" value="Open" />
-		(optional)
-	</div>
-	
-	<div class="w3-container w3-row" style="margin-top: 16px;">
-		<label for="tournamentIdB">Tournament 2: </label>
-		<input type="number" id="tournamentIdB" name="tournamentIdB" value="199019" />
-	</div>
-	<div class="w3-container w3-row" style="margin-top: 8px;">
-		<label for="tournamentShortNameB">Queue name: </label>
-		<input type="text" id="tournamentShortNameB" name="tournamentShortNameB" value="Women's" />
-		(optional)
-	</div>
-	
+
 	<div class="w3-row w3-container" style="margin-top: 16px;">
 		<button class="w3-button w3-green w3-hover-black w3-round" type="button" onclick="loadQueuesButton()">Load Queues</button>
 		<button class="w3-button w3-pale-red w3-hover-black w3-round" type="button" onclick="loadPlayersButton()">Load Missing Players</button>
 		<button class="w3-button w3-pale-green w3-hover-black w3-round" type="button" id="startAutoLoadButton" onclick="startAutoLoadQueuesButton()">Start Auto-refresh</button>
 		<button class="w3-button w3-pale-blue w3-hover-black w3-round w3-hide" type="button" id="stopAutoLoadButton" onclick="stopAutoLoadQueuesButton()">Stop Auto-refresh</button>
-		<span class="w3-hide" id="lastUpdated">Last updated: never</span>
+		<span class="nowrap w3-hide" id="lastUpdated">Last updated: never</span>
+		<button class="w3-button w3-dark-grey w3-hover-black w3-round w3-hide" type="button" id="showParametersButton" onclick="showParameters()">Show Parameters</button>
+		<button class="w3-button w3-dark-grey w3-hover-black w3-round" type="button" id="hideParametersButton" onclick="hideParameters()">Hide Parameters</button>
 	</div>
 
 	<div class="w3-row w3-container w3-hide" style="margin-top: 16px;" id="queueSummaryTitle">
-		<h2 class="w3-col s12 m10 l8">Queue Summary</h2>
+		<h3 class="w3-col s12 m10 l8">Queue Summary</h3>
 	</div>
 	<div class="w3-row w3-container w3-hide" id="queueSummaryHeader">
 		<div class="w3-col s3 m3 l3"><b>Arena</b></div>
@@ -84,22 +104,19 @@
 		<div class="w3-col s3 m3 l3 w3-border-top truncate"></div>
 	</div>
 
-	<div class="w3-row w3-container w3-hide" style="margin-top: 16px;" id="fullQueuesTitle">
-		<h2 class="w3-col s12 m10 l8">Full Queues</h2>
-	</div>
-	<div class="w3-row w3-container w3-hide" style="margin-top: 16px;" id="queueNameTemplate">
-		<h3 class="w3-col s12 m10 l8 truncate">Arena</h3>
+	<div class="w3-row w3-container w3-hide" style="margin-top: 8px;" id="queueNameTemplate">
+		<h4 class="w3-col s12 m10 l8 truncate">Arena</h4>
 	</div>
 	<div class="w3-row w3-container w3-hide" id="queueHeaderTemplate">
-		<div class="w3-col s2 m2 l1 w3-center"><b>#</b></div>
-		<div class="w3-col s4 m4 l4 truncate"><b>Player</b></div>
-		<div class="w3-col s3 m3 l2 truncate"><b>Queue</b></div>
+		<div class="w3-col s2 m2 l2 w3-center"><b>#</b></div>
+		<div class="w3-col s4 m5 l5 truncate"><b>Player</b></div>
+		<div class="w3-col s3 m2 l2 truncate"><b>Queue</b></div>
 		<div class="w3-col s3 m3 l3 w3-right-align truncate"><b>Waited</b></div>
 	</div>
 	<div class="w3-row w3-container w3-hide" id="queueRowTemplate">
-		<div class="w3-col s2 m2 l1 w3-border-top w3-center"></div>
-		<div class="w3-col s4 m4 l4 w3-border-top truncate"></div>
-		<div class="w3-col s3 m3 l2 w3-border-top truncate"></div>
+		<div class="w3-col s2 m2 l2 w3-border-top w3-center"></div>
+		<div class="w3-col s4 m5 l5 w3-border-top truncate"></div>
+		<div class="w3-col s3 m2 l2 w3-border-top truncate"></div>
 		<div class="w3-col s3 m3 l3 w3-border-top w3-right-align truncate"></div>
 	</div>
 

--- a/mergequeues.html
+++ b/mergequeues.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<link rel="stylesheet" href="css/w3.css">
+<head>
+    <meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Best Game Queue Merger</title>
+	<style>
+		.truncate {
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		.border-left-thick {
+			border-left: 5px solid #ccc;
+		}
+
+		.queue-list-flex {
+			flex-wrap: wrap;
+		}
+
+		.queue-flex {
+			flex-grow: 0;
+			flex-shrink: 0;
+			flex-basis: 470px;
+		}
+	</style>
+</head>
+
+<body onload="initializeFromStorage()">
+	<div w3-include-html="menu.html"></div>
+
+	<div class="w3-container w3-row" style="margin-top: 64px;">
+		<label for="matchPlayApiKey">Match Play Events API Token: </label>
+		<input type="password" id="matchPlayApiKey" name="matchPlayApiKey" />
+		<a class="w3-button" href="https://app.matchplay.events/api-docs/#authenticating-requests" title="Match Play Events API Authentication Documentation">🛈</a>
+		<a class="w3-button" href="https://app.matchplay.events/account/tokens" title="Create an API Token in your MPE Account Settings">🔑</a>
+		<button class="w3-button w3-dark-grey w3-hover-black w3-round" type="button" onclick="saveApiKey()" title="Writes your key to browser local storage">Save API Key</button>
+		<button class="w3-button w3-dark-grey w3-hover-black w3-round" type="button" onclick="clearSavedApiKey()" title="Clears any key saved in browser local storage">Clear Saved Key</button>
+	</div>
+	
+	<div class="w3-container w3-row" style="margin-top: 16px;">
+		<label for="tournamentIdA">Tournament 1: </label>
+		<input type="number" id="tournamentIdA" name="tournamentIdA" value="198946" />
+	</div>
+	<div class="w3-container w3-row" style="margin-top: 8px;">
+		<label for="tournamentShortNameA">Queue name: </label>
+		<input type="text" id="tournamentShortNameA" name="tournamentShortNameA" value="Open" />
+		(optional)
+	</div>
+	
+	<div class="w3-container w3-row" style="margin-top: 16px;">
+		<label for="tournamentIdB">Tournament 2: </label>
+		<input type="number" id="tournamentIdB" name="tournamentIdB" value="199019" />
+	</div>
+	<div class="w3-container w3-row" style="margin-top: 8px;">
+		<label for="tournamentShortNameB">Queue name: </label>
+		<input type="text" id="tournamentShortNameB" name="tournamentShortNameB" value="Women's" />
+		(optional)
+	</div>
+	
+	<div class="w3-row w3-container" style="margin-top: 16px;">
+		<button class="w3-button w3-green w3-hover-black w3-round" type="button" onclick="loadQueuesButton()">Load Queues</button>
+		<button class="w3-button w3-pale-red w3-hover-black w3-round" type="button" onclick="loadPlayersButton()">Load Missing Players</button>
+		<button class="w3-button w3-pale-green w3-hover-black w3-round" type="button" id="startAutoLoadButton" onclick="startAutoLoadQueuesButton()">Start Auto-refresh</button>
+		<button class="w3-button w3-pale-blue w3-hover-black w3-round w3-hide" type="button" id="stopAutoLoadButton" onclick="stopAutoLoadQueuesButton()">Stop Auto-refresh</button>
+		<span class="w3-hide" id="lastUpdated">Last updated: never</span>
+	</div>
+
+	<div class="w3-row w3-container w3-hide" style="margin-top: 16px;" id="queueSummaryTitle">
+		<h2 class="w3-col s12 m10 l8">Queue Summary</h2>
+	</div>
+	<div class="w3-row w3-container w3-hide" id="queueSummaryHeader">
+		<div class="w3-col s3 m3 l3"><b>Arena</b></div>
+		<div class="w3-col s3 m3 l3"><b>On Game</b></div>
+		<div class="w3-col s3 m3 l3"><b>Up Next</b></div>
+		<div class="w3-col s3 m3 l3"><b>3rd</b></div>
+	</div>
+	<div class="w3-row w3-container w3-hide" id="queueSummaryRowTemplate">
+		<div class="w3-col s3 m3 l3 w3-border-top truncate"></div>
+		<div class="w3-col s3 m3 l3 w3-border-top truncate"></div>
+		<div class="w3-col s3 m3 l3 w3-border-top truncate"></div>
+		<div class="w3-col s3 m3 l3 w3-border-top truncate"></div>
+	</div>
+
+	<div class="w3-row w3-container w3-hide" style="margin-top: 16px;" id="fullQueuesTitle">
+		<h2 class="w3-col s12 m10 l8">Full Queues</h2>
+	</div>
+	<div class="w3-row w3-container w3-hide" style="margin-top: 16px;" id="queueNameTemplate">
+		<h3 class="w3-col s12 m10 l8 truncate">Arena</h3>
+	</div>
+	<div class="w3-row w3-container w3-hide" id="queueHeaderTemplate">
+		<div class="w3-col s2 m2 l1 w3-center"><b>#</b></div>
+		<div class="w3-col s4 m4 l4 truncate"><b>Player</b></div>
+		<div class="w3-col s3 m3 l2 truncate"><b>Queue</b></div>
+		<div class="w3-col s3 m3 l3 w3-right-align truncate"><b>Waited</b></div>
+	</div>
+	<div class="w3-row w3-container w3-hide" id="queueRowTemplate">
+		<div class="w3-col s2 m2 l1 w3-border-top w3-center"></div>
+		<div class="w3-col s4 m4 l4 w3-border-top truncate"></div>
+		<div class="w3-col s3 m3 l2 w3-border-top truncate"></div>
+		<div class="w3-col s3 m3 l3 w3-border-top w3-right-align truncate"></div>
+	</div>
+
+	<div class="w3-container" style="margin-top: 32px;">
+		<h6 class="w3-opacity">
+			This utility is written by Tommy V as part of the pinball toolset created by Patrick F. aka gameboyf9.  All are welcome to <a href="https://github.com/gameboy9/gameboy9.github.io">check my work</a> and open an issue if there any problems or inaccuracies are found.
+		</h6>
+	</div>
+</body>
+<script src="js/mergequeues.js"></script>
+<script src="js/menu.js"></script>
+<script>includeHTML();</script>
+</html>

--- a/mergequeues.html
+++ b/mergequeues.html
@@ -17,6 +17,11 @@
 		}
 
 		/* Used in mergequeues.js */
+		.queue-list-grid-3 {
+			grid-template-columns:auto auto auto;
+		}
+
+		/* Used in mergequeues.js */
 		.queue-list-flex {
 			flex-wrap: wrap;
 		}
@@ -25,8 +30,27 @@
 		.queue-flex {
 			flex-grow: 0;
 			flex-shrink: 0;
-			flex-basis: 470px;
+			flex-basis: 444px;
 		}
+
+		/* Used in mergequeues.js */
+		.rounded-box {
+			border: 2px solid #ccc;
+			border-radius: 8px;
+			padding-bottom: 6px;
+			margin: 6px;
+		}
+
+		.rounded-box > .w3-container {
+			padding-left: 8px;
+			padding-right: 8px;
+		}
+
+		.box-heading {
+			margin-top: 0px;
+			margin-bottom: 0px;
+		}
+
 	</style>
 </head>
 
@@ -79,45 +103,55 @@
 	</div>
 
 	<div class="w3-row w3-container" style="margin-top: 16px;">
-		<button class="w3-button w3-green w3-hover-black w3-round" type="button" onclick="loadQueuesButton()">Load Queues</button>
-		<button class="w3-button w3-pale-red w3-hover-black w3-round" type="button" onclick="loadPlayersButton()">Load Missing Players</button>
+		<button class="w3-button w3-green w3-hover-black w3-round" type="button" id="loadQueuesButton" onclick="loadQueuesButton()">Load Queues</button>
+		<button class="w3-button w3-pale-red w3-hover-black w3-round" type="button" id="loadPlayersButton" onclick="loadPlayersButton()">Load Missing Players</button>
 		<button class="w3-button w3-pale-green w3-hover-black w3-round" type="button" id="startAutoLoadButton" onclick="startAutoLoadQueuesButton()">Start Auto-refresh</button>
 		<button class="w3-button w3-pale-blue w3-hover-black w3-round w3-hide" type="button" id="stopAutoLoadButton" onclick="stopAutoLoadQueuesButton()">Stop Auto-refresh</button>
 		<span class="nowrap w3-hide" id="lastUpdated">Last updated: never</span>
 		<button class="w3-button w3-dark-grey w3-hover-black w3-round w3-hide" type="button" id="showParametersButton" onclick="showParameters()">Show Parameters</button>
 		<button class="w3-button w3-dark-grey w3-hover-black w3-round" type="button" id="hideParametersButton" onclick="hideParameters()">Hide Parameters</button>
+		<div class="w3-container w3-row w3-text-red w3-hide" id="rateLimitedRequestMessage">
+			Your requests have been rate limited by the Match Play Events API. This message will disappear in 1 minute
+			when the rate limit expires. If you are rapidly clicking the load buttons, please slow down. If you are have
+			multiple people or devices sharing the same API token, please click Get Token to visit your MPE account
+			settings page and your own token just for this device.
+		</div>
+		<div class="w3-container w3-row w3-text-red w3-hide" style="margin-top: 8px;" id="matchPlayKeyInvalidMessage">
+			The Match Play Events API Token you provided was invalid. It may have been previously deleted from your
+			Match Play account. Please click Get Token to visit your MPE account settings page and create one.
+		</div>
+	</div>
+
+	<div class="w3-row w3-container w3-hide" id="queueNameTemplate">
+		<h4 class="w3-col s12 m10 l8 truncate box-heading">Arena</h4>
+	</div>
+	<div class="w3-row w3-container w3-hide" id="queueHeaderTemplate">
+		<div class="w3-col s1 m1 l1 w3-center"><b>#</b></div>
+		<div class="w3-col s5 m5 l5 truncate"><b>Player</b></div>
+		<div class="w3-col s3 m3 l3 truncate"><b>Queue</b></div>
+		<div class="w3-col s3 m3 l3 w3-center truncate"><b>Waited</b></div>
+	</div>
+	<div class="w3-row w3-container w3-hide" id="queueRowTemplate">
+		<div class="w3-col s1 m1 l1 w3-border-top w3-center"></div>
+		<div class="w3-col s5 m5 l5 w3-border-top truncate"></div>
+		<div class="w3-col s3 m3 l3 w3-border-top truncate"></div>
+		<div class="w3-col s3 m3 l3 w3-border-top w3-right-align truncate"></div>
 	</div>
 
 	<div class="w3-row w3-container w3-hide" style="margin-top: 16px;" id="queueSummaryTitle">
 		<h3 class="w3-col s12 m10 l8">Queue Summary</h3>
 	</div>
-	<div class="w3-row w3-container w3-hide" id="queueSummaryHeader">
+	<div class="w3-row w3-container w3-xlarge w3-hide" id="queueSummaryHeader">
 		<div class="w3-col s3 m3 l3"><b>Arena</b></div>
 		<div class="w3-col s3 m3 l3"><b>On Game</b></div>
 		<div class="w3-col s3 m3 l3"><b>Up Next</b></div>
 		<div class="w3-col s3 m3 l3"><b>3rd</b></div>
 	</div>
-	<div class="w3-row w3-container w3-hide" id="queueSummaryRowTemplate">
+	<div class="w3-row w3-container w3-xlarge w3-hide" id="queueSummaryRowTemplate">
 		<div class="w3-col s3 m3 l3 w3-border-top truncate"></div>
 		<div class="w3-col s3 m3 l3 w3-border-top truncate"></div>
 		<div class="w3-col s3 m3 l3 w3-border-top truncate"></div>
 		<div class="w3-col s3 m3 l3 w3-border-top truncate"></div>
-	</div>
-
-	<div class="w3-row w3-container w3-hide" style="margin-top: 8px;" id="queueNameTemplate">
-		<h4 class="w3-col s12 m10 l8 truncate">Arena</h4>
-	</div>
-	<div class="w3-row w3-container w3-hide" id="queueHeaderTemplate">
-		<div class="w3-col s2 m2 l2 w3-center"><b>#</b></div>
-		<div class="w3-col s4 m5 l5 truncate"><b>Player</b></div>
-		<div class="w3-col s3 m2 l2 truncate"><b>Queue</b></div>
-		<div class="w3-col s3 m3 l3 w3-right-align truncate"><b>Waited</b></div>
-	</div>
-	<div class="w3-row w3-container w3-hide" id="queueRowTemplate">
-		<div class="w3-col s2 m2 l2 w3-border-top w3-center"></div>
-		<div class="w3-col s4 m5 l5 w3-border-top truncate"></div>
-		<div class="w3-col s3 m2 l2 w3-border-top truncate"></div>
-		<div class="w3-col s3 m3 l3 w3-border-top w3-right-align truncate"></div>
 	</div>
 
 	<div class="w3-container" style="margin-top: 32px;">


### PR DESCRIPTION
Adds a utility that can pull queue information from two best game tournaments and merge them together. This is useful when two tournaments use the same machines and the organizer wants players to queue in the individual tournaments for scorekeeping purposes but to show up as one merged queue for player ordering purposes.