### PR TITLE
Added optimized initial pace calculation

### DIFF
--- a/js/calcknockout.js
+++ b/js/calcknockout.js
@@ -1,0 +1,238 @@
+class Player {
+	constructor(id, topScore) {
+		this.id = id;
+		this.topScore = topScore;
+		this.strikes = 0;
+		this.score = 0;
+	}
+}
+
+function calcKnockoutTournament(players, groupCount, startRound, finalStrikes, finalPlayers, paceIncrement, p21, p22, p31, p32, p33, p41, p42, p43, p44, type) {	
+	let strikeDist = [ 
+		[ p21, p22, p22, p22], 
+		[ p31, p32, p33, p33], 
+		[ p41, p42, p43, p44]
+	];
+
+	let topScore = 40000000.0;
+	let lowScore = 10000000.0;
+
+	let playerList = [];
+	let roundResult = [];
+	let finalEndPlayers = [];
+	let firstCutPlayers = [];
+	let mGamesList = [];
+	let playerGames = [ 0, 0, 0 ];
+	let firstIteration = "";
+	let survivingPlayers = players;
+	let iterations = 10000;
+
+	for (let h = 0; h < iterations; h++)
+	{
+		let round = 0;
+		let strightGames = 0.0;
+		survivingPlayers = players;
+		let finalPaceStrikes = -1;
+		let iterationRounds = [ 0, 0, 0 ];
+
+		playerList = [];
+		for (let i = 0; i < players; i++)
+		{
+			let p = new Player(i, (lowScore + ((topScore - lowScore) * (i / (players - 1)))));
+			playerList.push(p);
+		}
+		while (survivingPlayers > finalPlayers)
+		{
+			let singlePlayerMatches = [ 0, 0, 0 ];
+
+			round++;
+			if (round == startRound) {
+				finalPaceStrikes = finalStrikes;
+			} else if (round >= startRound) {
+				finalPaceStrikes += paceIncrement;
+			}
+
+			allowed = [...playerList];
+
+			while (allowed.length > 0)
+			{
+				let match = []
+				let matchPlayers = 4;
+				if (allowed.length === 9 || allowed.length === 6 || allowed.length === 5 || allowed.length === 3)
+					matchPlayers = 3;
+				else if (allowed.length ===  2)
+					matchPlayers = 2;
+
+				singlePlayerMatches[matchPlayers - 2]++;
+
+				for (let j = 0; j < matchPlayers; j++)
+				{
+					let chosenPlayer = getRandomInt(allowed.length);
+					match.push(allowed[chosenPlayer]);
+					match[j].score = getRandomInt(match[j].topScore);
+					allowed.splice(chosenPlayer, 1);
+				}
+
+				for (let j = 0; j < matchPlayers; j++)
+				{
+					let rank = 0; // Weird for someone to rank in 0th place, but since arrays are zero-based...
+					for (let k = 0; k < matchPlayers; k++)
+					{
+						if (k == j) continue;
+						if (match[j].score < match[k].score) rank++;
+					}
+
+					// This will carry over to playerList - match[j] is by reference.
+					match[j].strikes += strikeDist[matchPlayers - 2][rank];
+				}
+				
+			}
+			for (let j = 0; j < playerList.length; j++) 
+			{
+				if (playerList[j].strikes < finalPaceStrikes)
+				{
+					playerList.splice(j, 1);
+					survivingPlayers--;
+					j--;
+				}				
+			}
+			if (h == 0 && type === 1)
+				console.log("R" + round + " -  Players:  " + survivingPlayers + " - 4P:  " + singlePlayerMatches[2] + " - 3P:  " + singlePlayerMatches[1] + " - 2P:  " + singlePlayerMatches[0] + " - Pace: " + finalPaceStrikes);
+
+			if (round == startRound)
+				firstCutPlayers.push(survivingPlayers);
+			
+			if (singlePlayerMatches[0] >= singlePlayerMatches[1] && singlePlayerMatches[0] >= singlePlayerMatches[2]) iterationRounds[0]++;
+			else if (singlePlayerMatches[1] >= singlePlayerMatches[2]) iterationRounds[1]++;
+			else iterationRounds[2]++;
+			strightGames++;
+		}
+		finalEndPlayers.push(survivingPlayers);
+		if (h == 0 && type === 1)
+			console.log("End players:  " + survivingPlayers);
+
+		roundResult.push(round);
+		playerGames[0] += iterationRounds[0];
+		playerGames[1] += iterationRounds[1];
+		playerGames[2] += iterationRounds[2];
+		mGamesList.push(iterationRounds[0] + (1.5 * iterationRounds[1]) + (2 * iterationRounds[2]));
+	}
+
+	let roundAvg = average(roundResult);
+	let endPlayersAvg =  average(finalEndPlayers);
+	let cutPlayersAvg =  average(firstCutPlayers);
+	let totalGames = average(mGamesList);
+	let totalTGP = average(mGamesList);
+	let pct5 = parseInt(iterations * 0.05);
+	let pct95 = parseInt(iterations * 0.95);
+	roundResult.sort(function(a, b) { return a - b; });
+	finalEndPlayers.sort(function(a, b) { return a - b; });
+	firstCutPlayers.sort(function(a, b) { return a - b; });
+
+	if (type === 1) {
+		document.getElementById("2pGames").innerHTML = (playerGames[0] / iterations).toFixed(2);
+		document.getElementById("3pGames").innerHTML = (playerGames[1] / iterations).toFixed(2);
+		document.getElementById("4pGames").innerHTML = (playerGames[2] / iterations).toFixed(2);
+		document.getElementById("TotalGames").innerHTML = ((playerGames[0] + playerGames[1] + playerGames[2]) / iterations).toFixed(2);
+		document.getElementById("MeaningfulGames").innerHTML = totalGames.toFixed(2);
+		document.getElementById("ApproxTGP").innerHTML = (totalTGP * 4 > 100 ? "100.00% (maxed - " + (totalTGP * 4).toFixed(2) + "%)" : (totalTGP * 4).toFixed(2) + "%");
+		document.getElementById("AvgRounds").innerHTML = roundAvg.toFixed(2);
+		document.getElementById("ExtremeRounds").innerHTML = Math.min(...roundResult) + " / " + Math.max(...roundResult);
+		document.getElementById("ReasonableRounds").innerHTML = roundResult[pct5] + " / " + roundResult[pct95];
+		document.getElementById("AvgPlayers").innerHTML = endPlayersAvg.toFixed(2);
+		document.getElementById("ExtremePlayers").innerHTML = Math.min(...finalEndPlayers) + " / " + Math.max(...finalEndPlayers);
+		document.getElementById("ReasonablePlayers").innerHTML = finalEndPlayers[pct5] + " / " + finalEndPlayers[pct95];
+		document.getElementById("AvgCut").innerHTML = cutPlayersAvg.toFixed(2);
+		document.getElementById("ExtremeCut").innerHTML = Math.min(...firstCutPlayers) + " / " + Math.max(...firstCutPlayers);
+		document.getElementById("ReasonableCut").innerHTML = firstCutPlayers[pct5] + " / " + firstCutPlayers[pct95];
+	}
+
+	return {
+		roundResult: roundResult,
+		minRounds: Math.min(...roundResult),
+		maxRounds: Math.max(...roundResult),
+		pct5Rounds: roundResult[pct5],
+		pct95Rounds: roundResult[pct95]
+	};
+}
+
+function calcKnockoutTournamentOptimalPace(minPlayers, maxRoundsLimit, players, groupCount, startRound, finalStrikes, finalPlayers, paceIncrement, p21, p22, p31, p32, p33, p41, p42, p43, p44, type) {
+
+	// Step through the number of players and the number of strikes to find the combination that
+	// minimizes the starting pace while keeping the total number of rounds below the max rounds limit
+
+    const stepsToProcess = players - minPlayers + 2; // Plus 1 for pre- and  post-player processing
+    const progressPerPlayer = 1 / stepsToProcess;
+
+    if (minPlayers > players) {
+        const swap = players;
+        players = minPlayers;
+        minPlayers = swap;
+    }
+    
+	const strikesRecommendations = [];
+    const firstIterationStrikes = startRound * p41 + 1; // just past the maximum possible pace
+    const guessFirstIterationStrikes = startRound * average([p41, p42, p43, p44]);
+	let prevStrikes = firstIterationStrikes;
+	for (let testPlayers = players; testPlayers >= minPlayers; testPlayers--) {
+        const playersProcessed = players - testPlayers + 0.5;
+        postMessage({ progress: playersProcessed * progressPerPlayer });
+		// Starting point has either been constructed to be the minimum possible number of rounds
+		// or is from the previous larget player count which suppoted this number of strikes
+		strikesRecommendations[testPlayers] = prevStrikes;
+		for (let testStrikes = prevStrikes; testStrikes >= 0; testStrikes--) {
+			let calcResult = calcKnockoutTournament(testPlayers, groupCount, startRound, testStrikes, finalPlayers, paceIncrement, p21, p22, p31, p32, p33, p41, p42, p43, p44, type);
+
+			if (calcResult.maxRounds > maxRoundsLimit) {
+				// Passed the max rounds limit, move on to the next player count
+				break;
+			} else {
+				// Latest best values
+				strikesRecommendations[testPlayers] = testStrikes;
+				// Next player loop can start here
+				prevStrikes = testStrikes;
+			}	
+		}
+	}
+    postMessage({progress: (players - minPlayers + 1) * progressPerPlayer});
+
+	// Summarize by strikes
+	// Using forEach to skip undefined indexes of the sparse array
+	const playerRangeRecommendations = [];
+	strikesRecommendations.forEach((strikesValue, playerCount) => {
+		const range = playerRangeRecommendations[strikesValue]
+		if (range === undefined) {
+			playerRangeRecommendations[strikesValue] = { low: playerCount, high: playerCount };
+		} else {
+			range.high = playerCount;
+		}
+	});
+
+	console.dir(playerRangeRecommendations);
+    return playerRangeRecommendations;
+}
+
+function getRandomInt(max) {
+  return Math.floor(Math.random() * max);
+}
+
+function average(numbers) 
+{
+	let sum = 0;
+	for (let i = 0; i < numbers.length; i++) 
+	{
+		sum += numbers[i];
+	}
+	return sum / numbers.length;
+}
+
+onmessage = (e) => {
+    console.log("Worker: Initial message received from main script");
+    const optimalPaceOutput = calcKnockoutTournamentOptimalPace(...e.data);
+
+    console.log("Worker: Posting final message back to main script");
+    postMessage({ 
+        progress: 1,
+        playerRangeRecommendations: optimalPaceOutput
+    });
+};

--- a/js/pacematch.js
+++ b/js/pacematch.js
@@ -1,12 +1,3 @@
-class Player {
-	constructor(id, topScore) {
-		this.id = id;
-		this.topScore = topScore;
-		this.strikes = 0;
-		this.score = 0;
-	}
-}
-
 function fillStrikes() {
 	let value = document.getElementById("commonFormats").value;
 	if (value === "1") 
@@ -47,147 +38,6 @@ function fillStrikes() {
 	}
 }
 
-function calcKnockoutTournament(players, groupCount, startRound, finalStrikes, finalPlayers, paceIncrement, p21, p22, p31, p32, p33, p41, p42, p43, p44, type) {	
-	let strikeDist = [ 
-		[ p21, p22, p22, p22], 
-		[ p31, p32, p33, p33], 
-		[ p41, p42, p43, p44]
-	];
-
-	let topScore = 40000000.0;
-	let lowScore = 10000000.0;
-
-	let playerList = [];
-	let roundResult = [];
-	let finalEndPlayers = [];
-	let firstCutPlayers = [];
-	let mGamesList = [];
-	let playerGames = [ 0, 0, 0 ];
-	let firstIteration = "";
-	let survivingPlayers = players;
-	let iterations = 10000;
-
-	for (let h = 0; h < iterations; h++)
-	{
-		let round = 0;
-		let strightGames = 0.0;
-		survivingPlayers = players;
-		let finalPaceStrikes = -1;
-		let iterationRounds = [ 0, 0, 0 ];
-
-		playerList = [];
-		for (let i = 0; i < players; i++)
-		{
-			let p = new Player(i, (lowScore + ((topScore - lowScore) * (i / (players - 1)))));
-			playerList.push(p);
-		}
-		while (survivingPlayers > finalPlayers)
-		{
-			let singlePlayerMatches = [ 0, 0, 0 ];
-
-			round++;
-			if (round == startRound) {
-				finalPaceStrikes = finalStrikes;
-			} else if (round >= startRound) {
-				finalPaceStrikes += paceIncrement;
-			}
-
-			allowed = [...playerList];
-
-			while (allowed.length > 0)
-			{
-				let match = []
-				let matchPlayers = 4;
-				if (allowed.length === 9 || allowed.length === 6 || allowed.length === 5 || allowed.length === 3)
-					matchPlayers = 3;
-				else if (allowed.length ===  2)
-					matchPlayers = 2;
-
-				singlePlayerMatches[matchPlayers - 2]++;
-
-				for (let j = 0; j < matchPlayers; j++)
-				{
-					let chosenPlayer = getRandomInt(allowed.length);
-					match.push(allowed[chosenPlayer]);
-					match[j].score = getRandomInt(match[j].topScore);
-					allowed.splice(chosenPlayer, 1);
-				}
-
-				for (let j = 0; j < matchPlayers; j++)
-				{
-					let rank = 0; // Weird for someone to rank in 0th place, but since arrays are zero-based...
-					for (let k = 0; k < matchPlayers; k++)
-					{
-						if (k == j) continue;
-						if (match[j].score < match[k].score) rank++;
-					}
-
-					// This will carry over to playerList - match[j] is by reference.
-					match[j].strikes += strikeDist[matchPlayers - 2][rank];
-				}
-				
-			}
-			for (let j = 0; j < playerList.length; j++) 
-			{
-				if (playerList[j].strikes < finalPaceStrikes)
-				{
-					playerList.splice(j, 1);
-					survivingPlayers--;
-					j--;
-				}				
-			}
-			if (h == 0)
-				console.log("R" + round + " -  Players:  " + survivingPlayers + " - 4P:  " + singlePlayerMatches[2] + " - 3P:  " + singlePlayerMatches[1] + " - 2P:  " + singlePlayerMatches[0] + " - Pace: " + finalPaceStrikes);
-
-			if (round == startRound)
-				firstCutPlayers.push(survivingPlayers);
-			
-			if (singlePlayerMatches[0] >= singlePlayerMatches[1] && singlePlayerMatches[0] >= singlePlayerMatches[2]) iterationRounds[0]++;
-			else if (singlePlayerMatches[1] >= singlePlayerMatches[2]) iterationRounds[1]++;
-			else iterationRounds[2]++;
-			strightGames++;
-		}
-		finalEndPlayers.push(survivingPlayers);
-		if (h == 0)
-			console.log("End players:  " + survivingPlayers);
-
-		roundResult.push(round);
-		playerGames[0] += iterationRounds[0];
-		playerGames[1] += iterationRounds[1];
-		playerGames[2] += iterationRounds[2];
-		mGamesList.push(iterationRounds[0] + (1.5 * iterationRounds[1]) + (2 * iterationRounds[2]));
-	}
-
-	let roundAvg = average(roundResult);
-	let endPlayersAvg =  average(finalEndPlayers);
-	let cutPlayersAvg =  average(firstCutPlayers);
-	let totalGames = average(mGamesList);
-	let totalTGP = average(mGamesList);
-	let pct5 = parseInt(iterations * 0.05);
-	let pct95 = parseInt(iterations * 0.95);
-	roundResult.sort(function(a, b) { return a - b; });
-	finalEndPlayers.sort(function(a, b) { return a - b; });
-	firstCutPlayers.sort(function(a, b) { return a - b; });
-
-	if (type === 1) {
-		document.getElementById("2pGames").innerHTML = (playerGames[0] / iterations).toFixed(2);
-		document.getElementById("3pGames").innerHTML = (playerGames[1] / iterations).toFixed(2);
-		document.getElementById("4pGames").innerHTML = (playerGames[2] / iterations).toFixed(2);
-		document.getElementById("TotalGames").innerHTML = ((playerGames[0] + playerGames[1] + playerGames[2]) / iterations).toFixed(2);
-		document.getElementById("MeaningfulGames").innerHTML = totalGames.toFixed(2);
-		document.getElementById("ApproxTGP").innerHTML = (totalTGP * 4 > 100 ? "100.00% (maxed - " + (totalTGP * 4).toFixed(2) + "%)" : (totalTGP * 4).toFixed(2) + "%");
-		document.getElementById("AvgRounds").innerHTML = roundAvg.toFixed(2);
-		document.getElementById("ExtremeRounds").innerHTML = Math.min(...roundResult) + " / " + Math.max(...roundResult);
-		document.getElementById("ReasonableRounds").innerHTML = roundResult[pct5] + " / " + roundResult[pct95];
-		document.getElementById("AvgPlayers").innerHTML = endPlayersAvg.toFixed(2);
-		document.getElementById("ExtremePlayers").innerHTML = Math.min(...finalEndPlayers) + " / " + Math.max(...finalEndPlayers);
-		document.getElementById("ReasonablePlayers").innerHTML = finalEndPlayers[pct5] + " / " + finalEndPlayers[pct95];
-		document.getElementById("AvgCut").innerHTML = cutPlayersAvg.toFixed(2);
-		document.getElementById("ExtremeCut").innerHTML = Math.min(...firstCutPlayers) + " / " + Math.max(...firstCutPlayers);
-		document.getElementById("ReasonableCut").innerHTML = firstCutPlayers[pct5] + " / " + firstCutPlayers[pct95];
-	}
-}
-
 function tgpButton() {
 	let paceIncrement = parseInt(document.getElementById("paceIncrement").value);
 	let paceMinimum = (parseInt(document.getElementById("p41").value) + parseInt(document.getElementById("p44").value)) / 2 + 1;
@@ -196,7 +46,8 @@ function tgpButton() {
 		return;
 	}
 	
-	calcKnockoutTournament(parseInt(document.getElementById("playerCount").value),
+	calcKnockoutTournament(
+		parseInt(document.getElementById("playerCount").value),
 		parseInt(document.getElementById("groupCount").value),
 		parseInt(document.getElementById("paceRound").value),
 		parseInt(document.getElementById("strikes").value),
@@ -211,19 +62,91 @@ function tgpButton() {
 		parseInt(document.getElementById("p42").value),
 		parseInt(document.getElementById("p43").value),
 		parseInt(document.getElementById("p44").value),
-		1)
+		1);
 }
 
-function getRandomInt(max) {
-  return Math.floor(Math.random() * max);
-}
-
-function average(numbers) 
-{
-	let sum = 0;
-	for (let i = 0; i < numbers.length; i++) 
-	{
-		sum += numbers[i];
+function optimalPaceButton() {
+	let paceIncrement = parseInt(document.getElementById("paceIncrement").value);
+	let paceMinimum = (parseInt(document.getElementById("p41").value) + parseInt(document.getElementById("p44").value)) / 2 + 1;
+	if (paceIncrement < paceMinimum) {
+		alert("Invalid increment per round.  Must have a minimum of " + paceMinimum);
+		return;
 	}
-	return sum / numbers.length;
+
+	const myWorker = new Worker("js/calcknockout.js");
+
+	myWorker.onmessage = (e) => {
+		const messageData = e.data;
+		const progress = e.data.progress;
+		const playerRangeRecommendations = e.data.playerRangeRecommendations;
+
+		if (progress) {
+			const progressPercentage = (progress * 100).toFixed(0) + "%";
+			const progressElement = document.getElementById("optimalPaceProgress");
+			progressElement.style.width = progressPercentage;
+			progressElement.textContent = progressPercentage;
+		}
+
+		if (playerRangeRecommendations) {
+			// Pivot to player ranges
+			// Using forEach to skip undefined indexes of the sparse array
+			let recommendationsHtml = "";
+			playerRangeRecommendations.forEach((range, strikesValue) => {
+				if (range.low === range.high) {
+					recommendationsHtml += `${range.low} players: ${strikesValue} points <br>`;
+				} else {
+					recommendationsHtml += `${range.low} - ${range.high} players: ${strikesValue} points <br>`;
+				}
+			});
+			document.getElementById("OptimalInitialPace").innerHTML = recommendationsHtml;
+		}
+
+	};
+
+	console.log("Posting initial message posted to worker");
+	myWorker.postMessage([
+		parseInt(document.getElementById("playerCountLow").value),
+		parseInt(document.getElementById("maxRounds").value),
+		parseInt(document.getElementById("playerCount").value),
+		parseInt(document.getElementById("groupCount").value),
+		parseInt(document.getElementById("paceRound").value),
+		parseInt(document.getElementById("strikes").value),
+		parseInt(document.getElementById("playersLeft").value),
+		parseInt(document.getElementById("paceIncrement").value),
+		parseInt(document.getElementById("p21").value),
+		parseInt(document.getElementById("p22").value),
+		parseInt(document.getElementById("p31").value),
+		parseInt(document.getElementById("p32").value),
+		parseInt(document.getElementById("p33").value),
+		parseInt(document.getElementById("p41").value),
+		parseInt(document.getElementById("p42").value),
+		parseInt(document.getElementById("p43").value),
+		parseInt(document.getElementById("p44").value),
+		0]);
+}
+
+function showDetailed() {
+	for (const element of document.getElementsByClassName("optimized-only")) {
+		element.classList.add("w3-hide");
+	}
+	for (const element of document.getElementsByClassName("detailed-only")) {
+		element.classList.remove("w3-hide");
+	}
+}
+
+function showOptimized() {
+	for (const element of document.getElementsByClassName("optimized-only")) {
+		element.classList.remove("w3-hide");
+	}
+	for (const element of document.getElementsByClassName("detailed-only")) {
+		element.classList.add("w3-hide");
+	}
+}
+
+function handleLoad() {
+	if (window.Worker) {
+		// Web Workers are supported
+	} else {
+		document.getElementById("optimizedOption").disabled = true;
+	}
 }

--- a/pacematch.html
+++ b/pacematch.html
@@ -11,16 +11,30 @@
 	<div w3-include-html="menu.html"></div>
 	
 	<div class="w3-container w3-row" style="margin-top: 64px;">
+		<span>Calculation: </span><br />
+		<input type="radio" id="detailedOnlyOption" name="calculationType" onclick="showDetailed()" checked />
+		<label for="detailedOnlyOption">One detailed scenario</label><br />
+		<input type="radio" id="optimizedOption" name="calculationType" onclick="showOptimized()" />
+		<label for="optimizedOption">Optimize for a maximum rounds limit</label>
+	</div>
+
+	<div class="w3-container w3-row" style="margin-top: 16px;">
+		<input type="number" id="playerCountLow" name="playerCountLow" min="2" max="1000" value="16" class="optimized-only w3-hide" />
+		<label for="playerCountLow" class="optimized-only w3-hide">to </label>
 		<input type="number" id="playerCount" name="playerCount" min="2" max="1000" value="50" />
 		<label for="playerCount">contestants in </label>
 		<input type="number" id="groupCount" name="groupCount" min="2" max="4" value="4" />
-		<label for="playerCount"> player groups.  The pace starts at </label>
-		<input type="number" id="strikes" name="strikes" min="1" max="1000" value="30" />
-		<label for="paceRound">points at round </label>
+		<label for="playerCount"> player groups. The pace starts at </label>
+		<input type="number" id="strikes" name="strikes" min="1" max="1000" value="30" class="detailed-only"/>
+		<label for="paceRound" class="detailed-only">points. </label> 
+		<label for="maxRounds" class="optimized-only w3-hide">the lowest number of points that still guarantees the final player count is reached within</label>
+		<input type="number" id="maxRounds" name="maxRounds" min="1" max="50" value="13" class="optimized-only w3-hide" />
+		<label for="maxRounds" class="optimized-only w3-hide">rounds. </label>
+		<label for="paceRound">The initial pace is applied after round </label>
 		<input type="number" id="paceRound" name="paceRound" min="1" max="100" value="7" />
-		<label for="strikes">.  The pace will increase by </label>
+		<span>.  The pace will increase by </span>
 		<input type="number" id="paceIncrement" name="paceIncrement" min="1" max="100" value="7" />
-		<label for="strikes">points each round.  Eliminations will continue until </label>
+		<label for="paceIncrement">points each round.  Eliminations will continue until </label>
 		<input type="number" id="playersLeft" name="playersLeft" min="1" max="1000" value="1" />
 		<label for="playersLeft"> player(s) remain.</label>
 	</div>
@@ -59,74 +73,88 @@
 		</div>
 	</div>
 	
-	<div class="w3-row w3-container" style="margin-top: 16px;">
+	<div class="w3-row w3-container detailed-only" style="margin-top: 16px;">
 		<button class="w3-button w3-green w3-hover-black w3-round" type="button" onclick="tgpButton()">Calculate Tournament</button>
+	</div>
+
+	<div class="w3-row w3-container optimized-only w3-hide" style="margin-top: 16px;">
+		<button class="w3-button w3-blue w3-hover-black w3-round" type="button" onclick="optimalPaceButton()">Calculate Optimal Pace</button>
+		<div class="w3-light-grey" style="width: 80%; margin-top: 8px;">
+			<div class="w3-container w3-green w3-center" style="padding: 0px; height: 24px; width: 0%" id="optimalPaceProgress"></div>
+		</div>
 	</div>
 
 	<div class="w3-row w3-container" style="margin-top: 16px;">
 		<div class="w3-col s4 m4 l2"><b>Results</b></div>
 	</div>
-	<div class="w3-row w3-container">
-		<div class="w3-col s4 m4 l2">Meaningful Games</div>
-		<div class="w3-col s4 m4 l1 w3-right-align" id="MeaningfulGames"> </div>
+	<div class="w3-row w3-container optimized-only w3-hide">
+		<div class="w3-col s4 m4 l2">Optimal Intial Pace</div>
+		<div class="w3-col s8 m5 l3 w3-right-align" id="OptimalInitialPace"> </div>
 	</div>
-	<div class="w3-row w3-container">
-		<div class="w3-col s4 m4 l2">Approximate TGP</div>
-		<div class="w3-col s4 m4 l1 w3-right-align" id="ApproxTGP"></div>
+
+	<div class="detailed-only">
+		<div class="w3-row w3-container">
+			<div class="w3-col s4 m4 l2">Meaningful Games</div>
+			<div class="w3-col s4 m4 l1 w3-right-align" id="MeaningfulGames"> </div>
+		</div>
+		<div class="w3-row w3-container">
+			<div class="w3-col s4 m4 l2">Approximate TGP</div>
+			<div class="w3-col s4 m4 l1 w3-right-align" id="ApproxTGP"></div>
+		</div>
+		<div class="w3-row w3-container">
+			<div class="w3-col s4 m4 l2 w3-border-top">Average Rounds</div>
+			<div class="w3-col s4 m4 l1 w3-border-top w3-right-align" id="AvgRounds">&nbsp;</div>
+		</div>
+		<div class="w3-row w3-container">
+			<div class="w3-col s4 m4 l2">Least / Most rounds</div>
+			<div class="w3-col s4 m4 l1 w3-right-align" id="ExtremeRounds"> </div>
+		</div>
+		<div class="w3-row w3-container">
+			<div class="w3-col s4 m4 l2 w3-border-bottom">5th-95th %tile</div>
+			<div class="w3-col s4 m4 l1 w3-right-align w3-border-bottom" id="ReasonableRounds">&nbsp;</div>
+		</div>
+		<div class="w3-row w3-container">
+			<div class="w3-col s4 m4 l2">Avg 1st cut players</div>
+			<div class="w3-col s4 m4 l1 w3-right-align" id="AvgCut"></div>
+		</div>
+		<div class="w3-row w3-container">
+			<div class="w3-col s4 m4 l2">Least / Most players</div>
+			<div class="w3-col s4 m4 l1 w3-right-align" id="ExtremeCut"></div>
+		</div>
+		<div class="w3-row w3-container">
+			<div class="w3-col s4 m4 l2 w3-border-bottom">5th-95th %tile</div>
+			<div class="w3-col s4 m4 l1 w3-border-bottom w3-right-align" id="ReasonableCut">&nbsp;</div>
+		</div>
+		<div class="w3-row w3-container">
+			<div class="w3-col s4 m4 l2">Average end players</div>
+			<div class="w3-col s4 m4 l1 w3-right-align" id="AvgPlayers"></div>
+		</div>
+		<div class="w3-row w3-container">
+			<div class="w3-col s4 m4 l2">Least / Most players</div>
+			<div class="w3-col s4 m4 l1 w3-right-align" id="ExtremePlayers"></div>
+		</div>
+		<div class="w3-row w3-container">
+			<div class="w3-col s4 m4 l2 w3-border-bottom">5th-95th %tile</div>
+			<div class="w3-col s4 m4 l1 w3-border-bottom w3-right-align" id="ReasonablePlayers">&nbsp;</div>
+		</div>
+		<div class="w3-row w3-container">
+			<div class="w3-col s4 m4 l2">Avg Rounds-2P</div>
+			<div class="w3-col s4 m4 l1 w3-right-align" id="2pGames"></div>
+		</div>
+		<div class="w3-row w3-container">
+			<div class="w3-col s4 m4 l2">Avg Rounds-3P</div>
+			<div class="w3-col s4 m4 l1 w3-right-align" id="3pGames"></div>
+		</div>
+		<div class="w3-row w3-container">
+			<div class="w3-col s4 m4 l2">Avg Rounds-4P</div>
+			<div class="w3-col s4 m4 l1 w3-right-align" id="4pGames"></div>
+		</div>
+		<div class="w3-row w3-container">
+			<div class="w3-col s4 m4 l2">Avg Rounds-All</div>
+			<div class="w3-col s4 m4 l1 w3-right-align" id="TotalGames"></div>
+		</div>
 	</div>
-	<div class="w3-row w3-container">
-		<div class="w3-col s4 m4 l2 w3-border-top">Average Rounds</div>
-		<div class="w3-col s4 m4 l1 w3-border-top w3-right-align" id="AvgRounds">&nbsp;</div>
-	</div>
-	<div class="w3-row w3-container">
-		<div class="w3-col s4 m4 l2">Least / Most rounds</div>
-		<div class="w3-col s4 m4 l1 w3-right-align" id="ExtremeRounds"> </div>
-	</div>
-	<div class="w3-row w3-container">
-		<div class="w3-col s4 m4 l2 w3-border-bottom">5th-95th %tile</div>
-		<div class="w3-col s4 m4 l1 w3-right-align w3-border-bottom" id="ReasonableRounds">&nbsp;</div>
-	</div>
-	<div class="w3-row w3-container">
-		<div class="w3-col s4 m4 l2">Avg 1st cut players</div>
-		<div class="w3-col s4 m4 l1 w3-right-align" id="AvgCut"></div>
-	</div>
-	<div class="w3-row w3-container">
-		<div class="w3-col s4 m4 l2">Least / Most players</div>
-		<div class="w3-col s4 m4 l1 w3-right-align" id="ExtremeCut"></div>
-	</div>
-	<div class="w3-row w3-container">
-		<div class="w3-col s4 m4 l2 w3-border-bottom">5th-95th %tile</div>
-		<div class="w3-col s4 m4 l1 w3-border-bottom w3-right-align" id="ReasonableCut">&nbsp;</div>
-	</div>
-	<div class="w3-row w3-container">
-		<div class="w3-col s4 m4 l2">Average end players</div>
-		<div class="w3-col s4 m4 l1 w3-right-align" id="AvgPlayers"></div>
-	</div>
-	<div class="w3-row w3-container">
-		<div class="w3-col s4 m4 l2">Least / Most players</div>
-		<div class="w3-col s4 m4 l1 w3-right-align" id="ExtremePlayers"></div>
-	</div>
-	<div class="w3-row w3-container">
-		<div class="w3-col s4 m4 l2 w3-border-bottom">5th-95th %tile</div>
-		<div class="w3-col s4 m4 l1 w3-border-bottom w3-right-align" id="ReasonablePlayers">&nbsp;</div>
-	</div>
-	<div class="w3-row w3-container">
-		<div class="w3-col s4 m4 l2">Avg Rounds-2P</div>
-		<div class="w3-col s4 m4 l1 w3-right-align" id="2pGames"></div>
-	</div>
-	<div class="w3-row w3-container">
-		<div class="w3-col s4 m4 l2">Avg Rounds-3P</div>
-		<div class="w3-col s4 m4 l1 w3-right-align" id="3pGames"></div>
-	</div>
-	<div class="w3-row w3-container">
-		<div class="w3-col s4 m4 l2">Avg Rounds-4P</div>
-		<div class="w3-col s4 m4 l1 w3-right-align" id="4pGames"></div>
-	</div>
-	<div class="w3-row w3-container">
-		<div class="w3-col s4 m4 l2">Avg Rounds-All</div>
-		<div class="w3-col s4 m4 l1 w3-right-align" id="TotalGames"></div>
-	</div>
-	
+
 	<div class="w3-container" style="margin-top: 32px;">
 		<h6 class="w3-opacity">
 			DISCLAIMER:  This calculator assumes that the highest rated player will defeat the lowest rated player 7 times out of 8.
@@ -139,6 +167,7 @@
 		</h6>
 	</div>
 </body>
+<script src="js/calcknockout.js"></script>
 <script src="js/pacematch.js"></script>
 <script src="js/menu.js"></script>
 <script>includeHTML();</script>


### PR DESCRIPTION
Invert the pace questions so that the user can say how many rounds they want to play (at a maximum) and give a range of players and get a result that shows what the pace should be for each player count.

Keep in mind that a) it's unlikely that the tournament will actually hit the maximum rounds and b) some of the rounds may be majority or all 3-player groups and take less time so the input should be a little higher than your really want.